### PR TITLE
iolist encoding option, new encoding utility

### DIFF
--- a/lib/hui/encode.ex
+++ b/lib/hui/encode.ex
@@ -137,6 +137,7 @@ defmodule Hui.Encode do
   defp _encode({k, v}, %{format: :json}, {eql, sep}),
     do: ["\"", to_string(k), "\"", eql, Poison.encode!(v), sep]
 
+  ## TODO: refactor transform concerns into a separate module
   @doc """
   Transforms built-in query structs to keyword list.
 

--- a/lib/hui/encode1.ex
+++ b/lib/hui/encode1.ex
@@ -19,21 +19,16 @@ defmodule Hui.EncodeNew do
   end
 
   @doc """
-  Encodes keywords list to IO data.
+  Encodes keywords list into IO data.
   """
-  @spec encode(list(keyword)) :: iodata
-  def encode(query)
-
+  @spec encode(list(keyword)) :: iodata()
   def encode([]), do: []
-  def encode(query) when is_list(query), do: transform(query, @url_delimiters)
+  def encode(query) when is_list(query), do: transform(sanitise(query), @url_delimiters)
 
   defp transform([h | t], delimiters), do: transform({h, t}, delimiters)
 
   # expands and transforms fq: [x, y, z] => "fq=x&fq=&fq=z"
-  defp transform({{k, v}, t}, _delimiters) when is_list(v) do
-    encode(Enum.map(v, &{k, &1}) ++ t)
-  end
-
+  defp transform({{k, v}, t}, _delimiters) when is_list(v), do: encode(Enum.map(v, &{k, &1}) ++ t)
   defp transform({h, []}, {eql, _delimiter}), do: [key(h), eql, value(h)]
 
   defp transform({h, t}, {eql, delimiter}) do
@@ -43,4 +38,11 @@ defmodule Hui.EncodeNew do
   defp key({k, _v}), do: to_string(k)
 
   defp value({_k, v}), do: URI.encode_www_form(to_string(v))
+
+  defp sanitise(query) do
+    query
+    |> Enum.reject(fn {k, v} ->
+      v in ["", nil, []] or k == :__struct__ or k == :per_field
+    end)
+  end
 end

--- a/lib/hui/encode1.ex
+++ b/lib/hui/encode1.ex
@@ -21,16 +21,26 @@ defmodule Hui.EncodeNew do
   @doc """
   Encodes keywords list to IO data.
   """
-  @spec encode(list(keyword), options) :: iodata
-  def encode(query, opts \\ %Options{})
+  @spec encode(list(keyword)) :: iodata
+  def encode(query)
 
-  def encode(query, opts) when is_list(query), do: transform(query, opts, @url_delimiters)
+  def encode([]), do: []
+  def encode(query) when is_list(query), do: transform(query, @url_delimiters)
 
-  def transform([{k, v} | []], opts, {eql, _}) do
-    [to_string(k), eql, URI.encode_www_form(to_string(v))]
+  defp transform([h | t], delimiters), do: transform({h, t}, delimiters)
+
+  # expands and transforms fq: [x, y, z] => "fq=x&fq=&fq=z"
+  defp transform({{k, v}, t}, _delimiters) when is_list(v) do
+    encode(Enum.map(v, &{k, &1}) ++ t)
   end
 
-  def transform([{k, v} | t], opts, {eql, delimiter}) do
-    [to_string(k), eql, URI.encode_www_form(to_string(v)), delimiter | [transform(t, opts, {eql, delimiter})]]
+  defp transform({h, []}, {eql, _delimiter}), do: [key(h), eql, value(h)]
+
+  defp transform({h, t}, {eql, delimiter}) do
+    [key(h), eql, value(h), delimiter | [transform(t, {eql, delimiter})]]
   end
+
+  defp key({k, _v}), do: to_string(k)
+
+  defp value({_k, v}), do: URI.encode_www_form(to_string(v))
 end

--- a/lib/hui/encode1.ex
+++ b/lib/hui/encode1.ex
@@ -1,0 +1,36 @@
+defmodule Hui.EncodeNew do
+  @moduledoc """
+  Utilities for encoding Solr query and update data structures.
+  """
+
+  @type query :: Hui.Query.solr_query()
+  @type options :: Hui.Encode.Options.t()
+
+  @url_delimiters {?=, ?&}
+
+  defmodule Options do
+    defstruct [:per_field, :prefix, format: :url]
+
+    @type t :: %__MODULE__{
+            format: :url | :json,
+            per_field: binary,
+            prefix: binary
+          }
+  end
+
+  @doc """
+  Encodes keywords list to IO data.
+  """
+  @spec encode(list(keyword), options) :: iodata
+  def encode(query, opts \\ %Options{})
+
+  def encode(query, opts) when is_list(query), do: transform(query, opts, @url_delimiters)
+
+  def transform([{k, v} | []], opts, {eql, _}) do
+    [to_string(k), eql, URI.encode_www_form(to_string(v))]
+  end
+
+  def transform([{k, v} | t], opts, {eql, delimiter}) do
+    [to_string(k), eql, URI.encode_www_form(to_string(v)), delimiter | [transform(t, opts, {eql, delimiter})]]
+  end
+end

--- a/lib/hui/encoder.ex
+++ b/lib/hui/encoder.ex
@@ -67,7 +67,7 @@ defimpl Hui.Encoder, for: [Query.Facet, Query.MoreLikeThis, Query.SpellCheck, Qu
 
   def encode(query) do
     {prefix, _} = Hui.URLPrefixField.prefix_field()[query.__struct__]
-    options = %Encode.Options{prefix: prefix}
+    options = %EncodeNew.Options{prefix: prefix}
 
     query
     |> Map.to_list()
@@ -97,7 +97,7 @@ defimpl Hui.Encoder,
     {prefix, field_key} = Hui.URLPrefixField.prefix_field()[query.__struct__]
     per_field_field = query |> Map.get(field_key)
 
-    options = %Encode.Options{
+    options = %EncodeNew.Options{
       prefix: prefix,
       per_field: if(query.per_field, do: per_field_field, else: nil)
     }
@@ -142,7 +142,6 @@ defimpl Hui.Encoder, for: Map do
   end
 end
 
-# TODO: implement iolist option
 defimpl Hui.Encoder, for: List do
   # encode a list of map or structs
   def encode([x | y], %{format: format}) when is_map(x) do

--- a/lib/hui/encoder.ex
+++ b/lib/hui/encoder.ex
@@ -99,8 +99,9 @@ defimpl Hui.Encoder,
     }
 
     query
-    |> Encode.transform(options)
-    |> Encode.encode(options)
+    |> Map.to_list()
+    |> EncodeNew.sanitise()
+    |> EncodeNew.encode(options)
   end
 end
 
@@ -133,7 +134,7 @@ defimpl Hui.Encoder, for: Map do
   def encode(query) do
     query
     |> Map.to_list()
-    |> Encode.encode()
+    |> EncodeNew.encode()
   end
 end
 
@@ -155,6 +156,6 @@ defimpl Hui.Encoder, for: List do
     end
   end
 
-  def encode([x | y]) when is_tuple(x), do: Encode.encode([x | y])
+  def encode([x | y]) when is_tuple(x), do: EncodeNew.encode([x | y])
   def encode([]), do: ""
 end

--- a/lib/hui/encoder.ex
+++ b/lib/hui/encoder.ex
@@ -51,6 +51,7 @@ defimpl Hui.Encoder, for: [Query.Standard, Query.Common, Query.DisMax] do
   def encode(query) do
     query
     |> Map.to_list()
+    |> EncodeNew.sanitise()
     |> EncodeNew.encode()
   end
 end
@@ -69,8 +70,9 @@ defimpl Hui.Encoder, for: [Query.Facet, Query.MoreLikeThis, Query.SpellCheck, Qu
     options = %Encode.Options{prefix: prefix}
 
     query
-    |> Encode.transform(options)
-    |> Encode.encode(options)
+    |> Map.to_list()
+    |> EncodeNew.sanitise()
+    |> EncodeNew.encode(options)
   end
 end
 

--- a/lib/hui/encoder.ex
+++ b/lib/hui/encoder.ex
@@ -2,6 +2,8 @@ alias Hui.Query
 alias Hui.Encode
 alias Hui.Encode.Options
 
+alias Hui.EncodeNew
+
 defprotocol Hui.Encoder do
   @moduledoc """
   A protocol that underpins Solr query encoding.
@@ -49,7 +51,7 @@ defimpl Hui.Encoder, for: [Query.Standard, Query.Common, Query.DisMax] do
   def encode(query) do
     query
     |> Map.to_list()
-    |> Encode.encode()
+    |> EncodeNew.encode()
   end
 end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -10,8 +10,8 @@ defmodule HuiEncodeTest do
   import Hui.EncodeNew
   alias Hui.EncodeNew.Options
 
-  describe "encode/1 keywords" do
-    test "into IO list" do
+  describe "when encoding format is :url" do
+    test "encode/1 keywords" do
       query = [q: "loch", "q.op": "AND", sow: true, rows: 61]
       io_list = ["q", 61, "loch", 38, ["q.op", 61, "AND", 38, ["sow", 61, "true", 38, ["rows", 61, "61"]]]]
 
@@ -20,12 +20,12 @@ defmodule HuiEncodeTest do
     end
 
     # TODO: more tests for specific Solr query syntax
-    test "with Solr local params value into IO list" do
+    test "encode/1 keywords with Solr local params" do
       assert encode(q: "series_t:(blac? OR ambe*)") == ["q", 61, "series_t%3A%28blac%3F+OR+ambe%2A%29"]
     end
 
     # fq: [x] => "fq=x"
-    test "with a single-value list into IO list" do
+    test "encode/1 keywords with a single-value list" do
       query = [q: "loch", fq: ["type:image"]]
 
       assert encode(query) == ["q", 61, "loch", 38, ["fq", 61, "type%3Aimage"]]
@@ -33,7 +33,7 @@ defmodule HuiEncodeTest do
     end
 
     # fq: [x, y, z] => "fq=x&fq=y&fq=z"
-    test "with a list value into IO list" do
+    test "encode/1 keywords with a list value" do
       query = [
         wt: "json",
         fq: ["cat:book", "inStock:true", "price:[1.99 TO 9.99]"],
@@ -58,6 +58,73 @@ defmodule HuiEncodeTest do
 
       assert encode(query) |> to_string ==
                "wt=json&fq=cat%3Abook&fq=inStock%3Atrue&fq=price%3A%5B1.99+TO+9.99%5D&fl=id%2Cname"
+    end
+
+    test "encode/2 facet struct" do
+      opts = %Options{prefix: "facet"}
+
+      encoded_io_list =
+        %Query.Facet{field: ["cat", "author_str"], mincount: 1}
+        |> Map.to_list()
+        |> sanitise()
+        |> encode(opts)
+
+      assert encoded_io_list == [
+               "facet",
+               61,
+               "true",
+               38,
+               ["facet.field", 61, "cat", 38, ["facet.field", 61, "author_str", 38, ["facet.mincount", 61, "1"]]]
+             ]
+
+      assert encoded_io_list |> to_string == "facet=true&facet.field=cat&facet.field=author_str&facet.mincount=1"
+    end
+
+    test "encode/2 facet range struct" do
+      opts = %Options{prefix: "facet"}
+
+      encoded_io_list =
+        %Query.FacetRange{range: "price", start: 0, end: 100, gap: 10, per_field: true}
+        |> Map.to_list()
+        |> sanitise()
+        |> encode(opts)
+
+      assert encoded_io_list == [
+               "facet.end",
+               61,
+               "100",
+               38,
+               ["facet.gap", 61, "10", 38, ["facet.range", 61, "price", 38, ["facet.start", 61, "0"]]]
+             ]
+
+      assert encoded_io_list |> to_string == "facet.end=100&facet.gap=10&facet.range=price&facet.start=0"
+    end
+
+    test "encode/2 facet per-field range struct" do
+      opts = %Options{prefix: "facet", per_field: "price"}
+
+      encoded_io_list =
+        %Query.FacetRange{range: "price", start: 0, end: 100, gap: 10, per_field: true}
+        |> Map.to_list()
+        |> sanitise()
+        |> encode(opts)
+
+      assert encoded_io_list == [
+               "f.price.facet.end",
+               61,
+               "100",
+               38,
+               [
+                 "f.price.facet.gap",
+                 61,
+                 "10",
+                 38,
+                 ["f.price.facet.range", 61, "price", 38, ["f.price.facet.start", 61, "0"]]
+               ]
+             ]
+
+      assert encoded_io_list |> to_string ==
+               "f.price.facet.end=100&f.price.facet.gap=10&f.price.facet.range=price&f.price.facet.start=0"
     end
   end
 
@@ -183,29 +250,6 @@ defmodule HuiEncodeTest do
   end
 
   describe "transform" do
-    test "query struct" do
-      x = %Query.Facet{field: ["cat", "author_str"], mincount: 1}
-      opts = %Encode.Options{prefix: "facet"}
-
-      expected = [facet: true, field: ["cat", "author_str"], mincount: 1]
-      assert Encode.transform(x) == expected
-
-      expected = [facet: true, "facet.field": ["cat", "author_str"], "facet.mincount": 1]
-      assert Encode.transform(x, opts) == expected
-
-      x = %Query.FacetRange{range: "price", start: 0, end: 100, gap: 10, per_field: true}
-      opts = %Encode.Options{prefix: "facet", per_field: "price"}
-
-      expected = [
-        "f.price.facet.end": 100,
-        "f.price.facet.gap": 10,
-        "f.price.facet.range": "price",
-        "f.price.facet.start": 0
-      ]
-
-      assert Encode.transform(x, opts) == expected
-    end
-
     # test transformation of update structs into ordered keyword lists
     test "update struct: doc, commitWithin, overwrite" do
       x = %Query.Update{doc: Fixtures.Update.single_doc(), commitWithin: 10, overwrite: true}

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -5,18 +5,18 @@ defmodule HuiEncodeTest do
   alias Hui.Encode.Options
   alias Hui.Query
 
-  describe "encode" do
-    test "IO data" do
-      x = [df: "words_txt", q: "loch", "q.op": "AND", sow: true]
+  # new encoder being developed gradually
+  # for https://github.com/boonious/hui/issues/7
+  alias Hui.EncodeNew
+  alias Hui.EncodeNew.Options
 
-      expected = [
-        ["df", "=", "words_txt", "&"],
-        ["q", "=", "loch", "&"],
-        ["q.op", "=", "AND", "&"],
-        ["sow", "=", "true", ""]
-      ]
+  describe "encode/2" do
+    test "keywords query into IO list" do
+      query = [q: "loch", "q.op": "AND", sow: true, rows: 61]
+      io_list = ["q", 61, "loch", 38, ["q.op", 61, "AND", 38, ["sow", 61, "true", 38, ["rows", 61, "61"]]]]
 
-      assert Encode.encode(x) == expected
+      assert EncodeNew.encode(query) == io_list
+      assert EncodeNew.encode(query) |> IO.iodata_to_binary() == "q=loch&q.op=AND&sow=true&rows=61"
     end
 
     test "omit nil or empty keywords" do

--- a/test/encoder_test.exs
+++ b/test/encoder_test.exs
@@ -23,10 +23,17 @@ defmodule HuiEncoderTest do
 
     test "in iolist format", %{query: query} do
       assert Encoder.encode(query, %{format: :iolist}) == [
-               ["fl", "=", "id%2Cname", "&"],
-               ["fq=cat%3Abook&fq=price%3A%5B1.99+TO+9.99%5D", "&"],
-               ["q", "=", "harry", "&"],
-               ["rows", "=", "10", ""]
+               "fl",
+               61,
+               "id%2Cname",
+               38,
+               [
+                 "fq",
+                 61,
+                 "cat%3Abook",
+                 38,
+                 ["fq", 61, "price%3A%5B1.99+TO+9.99%5D", 38, ["q", 61, "harry", 38, ["rows", 61, "10"]]]
+               ]
              ]
     end
   end
@@ -38,23 +45,18 @@ defmodule HuiEncoderTest do
 
     test "in iolist format" do
       assert Encoder.encode([q: "harry", rows: 10, start: 100], %{format: :iolist}) == [
-               ["q", "=", "harry", "&"],
-               ["rows", "=", "10", "&"],
-               ["start", "=", "100", ""]
+               "q",
+               61,
+               "harry",
+               38,
+               ["rows", 61, "10", 38, ["start", 61, "100"]]
              ]
     end
   end
 
-  test "encodes should handle empty, nil values / lists" do
+  test "encoder should raise error when query encoding is not defined" do
     assert_raise Protocol.UndefinedError, fn -> Hui.Encoder.encode(nil) end
     assert_raise Protocol.UndefinedError, fn -> Hui.Encoder.encode("") end
-
-    assert "" == Hui.Encoder.encode(q: "")
-    assert "" == Hui.Encoder.encode(fq: [])
-    assert "" == Hui.Encoder.encode(fl: nil)
-    assert "" == Hui.Encoder.encode(q: nil, fq: "")
-    assert "" == Hui.Encoder.encode(q: nil, fq: [])
-    assert "fq=date&fq=year" == Hui.Encoder.encode(q: nil, fq: ["", "date", nil, "", "year"])
   end
 
   test "encodes Standard struct" do

--- a/test/encoder_test.exs
+++ b/test/encoder_test.exs
@@ -5,28 +5,44 @@ defmodule HuiEncoderTest do
   alias Hui.Encoder
   alias Hui.Query
 
-  test "encodes map" do
-    assert Encoder.encode(%{q: "loch", rows: 10}) == "q=loch&rows=10"
+  describe "encode map" do
+    setup do
+      %{
+        query: %{
+          q: "harry",
+          rows: 10,
+          fq: ["cat:book", "price:[1.99 TO 9.99]"],
+          fl: "id,name"
+        }
+      }
+    end
 
-    assert Encoder.encode(%{
-             q: "harry",
-             wt: "json",
-             fq: ["cat:book", "inStock:true", "price:[1.99 TO 9.99]"],
-             fl: "id,name,author,price"
-           }) ==
-             "fl=id%2Cname%2Cauthor%2Cprice&fq=cat%3Abook&fq=inStock%3Atrue&fq=price%3A%5B1.99+TO+9.99%5D&q=harry&wt=json"
+    test "in binary format", %{query: query} do
+      assert Encoder.encode(query) == "fl=id%2Cname&fq=cat%3Abook&fq=price%3A%5B1.99+TO+9.99%5D&q=harry&rows=10"
+    end
+
+    test "in iolist format", %{query: query} do
+      assert Encoder.encode(query, %{format: :iolist}) == [
+               ["fl", "=", "id%2Cname", "&"],
+               ["fq=cat%3Abook&fq=price%3A%5B1.99+TO+9.99%5D", "&"],
+               ["q", "=", "harry", "&"],
+               ["rows", "=", "10", ""]
+             ]
+    end
   end
 
-  test "encodes keyword list" do
-    assert Encoder.encode(q: "loch", rows: 10) == "q=loch&rows=10"
+  describe "encode keyword list" do
+    test "in binary format" do
+      assert Encoder.encode(q: "loch", rows: 10) == "q=loch&rows=10"
+    end
 
-    assert Encoder.encode(
-             q: "harry",
-             wt: "json",
-             fq: ["cat:book", "inStock:true", "price:[1.99 TO 9.99]"],
-             fl: "id,name,author,price"
-           ) ==
-             "q=harry&wt=json&fq=cat%3Abook&fq=inStock%3Atrue&fq=price%3A%5B1.99+TO+9.99%5D&fl=id%2Cname%2Cauthor%2Cprice"
+    test "in iolist format" do
+      assert Encoder.encode([q: "harry", rows: 10, start: 100], %{format: :iolist}) == [
+               ["q", "=", "harry", "&"],
+               ["rows", "=", "10", "&"],
+               ["start", "=", "100", ""]
+             ]
+    end
   end
 
   test "encodes should handle empty, nil values / lists" do


### PR DESCRIPTION
- specify an iolist encoding option in `Encoder` protocol + implementation, to be the default option in due course.
- introduce a new more streamlined URL encoding utility `EncodeNew.encode` for all query types (keywords, map and `hui` query structs), based on nested iodata and body-recursive functions, to replace `Encode` in due course.