### PR TITLE
support additional endpoint fields in configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ erl_crash.dump
 hui-*.tar
 
 /.elixir_ls
+
+.tool-versions
+.DS_Store

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,3 +21,22 @@ config :hui, :update_test,
 config :hui, :update_struct_test,
   url: "http://localhost:9000/solr/articles/update",
   headers: [{"content-type", "application/json"}]
+
+config :hui, :url_handler,
+  url: "http://localhost:8983/solr/gettingstarted",
+  handler: "select",
+  headers: [{"accept", "application/json"}],
+  options: [timeout: 10000]
+
+config :hui, :url_collection,
+  url: "http://localhost:8983/solr",
+  collection: "gettingstarted",
+  headers: [{"accept", "application/json"}],
+  options: [timeout: 10000]
+
+config :hui, :url_collection_handler,
+  url: "http://localhost:8983/solr",
+  collection: "gettingstarted",
+  handler: "update",
+  headers: [{"accept", "application/json"}],
+  options: [timeout: 10000]

--- a/lib/hui.ex
+++ b/lib/hui.ex
@@ -22,7 +22,7 @@ defmodule Hui do
 
   @http_client Application.get_env(:hui, :http_client, Hui.Http)
 
-  @type url :: binary | atom | {binary, list} | {binary, list, list}
+  @type endpoint :: binary | atom | {binary, list} | {binary, list, list}
 
   @type querying_struct :: Query.Standard.t() | Query.Common.t() | Query.DisMax.t()
   @type faceting_struct :: Query.Facet.t() | Query.FacetRange.t() | Query.FacetInterval.t()
@@ -44,7 +44,7 @@ defmodule Hui do
   Issue a keyword list or structured query to the default Solr endpoint.
 
   The query can either be a keyword list or a list of Hui structs - see `t:Hui.solr_struct/0`.
-  This function is a shortcut for `search/2` with `:default` as URL key.
+  This function is a shortcut for `search/2` with `:default` as the configured endpoint key.
 
   ### Example
 
@@ -162,8 +162,8 @@ defmodule Hui do
   }
   ```
   """
-  @spec search(url, query) :: http_response
-  def search(url, query) when is_list(query) or is_map(query), do: get(url, query)
+  @spec search(endpoint, query) :: http_response
+  def search(endpoint, query) when is_list(query) or is_map(query), do: get(endpoint, query)
 
   @doc """
   Convenience function for issuing various typical queries to a specified Solr endpoint.
@@ -171,7 +171,7 @@ defmodule Hui do
   See `q/6`.
   """
   @spec search(
-          url,
+          endpoint,
           binary,
           nil | integer,
           nil | integer,
@@ -179,18 +179,18 @@ defmodule Hui do
           nil | binary | list(binary),
           nil | binary
         ) :: http_response
-  def search(url, keywords, rows \\ nil, start \\ nil, filters \\ nil, facet_fields \\ nil, sort \\ nil)
+  def search(endpoint, keywords, rows \\ nil, start \\ nil, filters \\ nil, facet_fields \\ nil, sort \\ nil)
 
-  def search(url, keywords, _, _, _, _, _) when is_nil_empty(keywords) or is_nil_empty(url),
+  def search(endpoint, keywords, _, _, _, _, _) when is_nil_empty(keywords) or is_nil_empty(endpoint),
     do: {:error, %Error{reason: :einval}}
 
-  def search(url, keywords, nil, nil, nil, nil, nil) do
-    get(url, %Query.Standard{q: keywords})
+  def search(endpoint, keywords, nil, nil, nil, nil, nil) do
+    get(endpoint, %Query.Standard{q: keywords})
   end
 
-  def search(url, keywords, rows, start, filters, facet_fields, sort) do
+  def search(endpoint, keywords, rows, start, filters, facet_fields, sort) do
     get(
-      url,
+      endpoint,
       [
         %Query.Standard{q: keywords},
         %Query.Common{rows: rows, start: start, fq: filters, sort: sort},
@@ -205,12 +205,13 @@ defmodule Hui do
   ### Example
 
   ```
+    # :library is a configured endpoint
     suggest_query = %Hui.Query.Suggest{q: "ha", count: 10, dictionary: "name_infix"}
     Hui.suggest(:library, suggest_query)
   ```
   """
-  @spec suggest(url, Query.Suggest.t()) :: http_response
-  def suggest(url, %Query.Suggest{} = query), do: get(url, query)
+  @spec suggest(endpoint, Query.Suggest.t()) :: http_response
+  def suggest(endpoint, %Query.Suggest{} = query), do: get(endpoint, query)
 
   @doc """
   Convenience function for issuing a suggester query to a specified Solr endpoint.
@@ -218,16 +219,20 @@ defmodule Hui do
   ### Example
 
   ```
+    # :autocomplete is a configured endpoint
     Hui.suggest(:autocomplete, "t")
     Hui.suggest(:autocomplete, "bo", 5, ["name_infix", "ln_prefix", "fn_prefix"], "1939")
   ```
   """
-  @spec suggest(url, binary, nil | integer, nil | binary | list(binary), nil | binary) :: http_response
-  def suggest(url, q, count \\ nil, dictionaries \\ nil, context \\ nil)
-  def suggest(url, q, _, _, _) when is_nil_empty(q) or is_nil_empty(url), do: {:error, %Error{reason: :einval}}
+  @spec suggest(endpoint, binary, nil | integer, nil | binary | list(binary), nil | binary) :: http_response
+  def suggest(endpoint, q, count \\ nil, dictionaries \\ nil, context \\ nil)
 
-  def suggest(url, q, count, dictionaries, context) do
-    get(url, %Query.Suggest{q: q, count: count, dictionary: dictionaries, cfq: context})
+  def suggest(endpoint, q, _, _, _) when is_nil_empty(q) or is_nil_empty(endpoint) do
+    {:error, %Error{reason: :einval}}
+  end
+
+  def suggest(endpoint, q, count, dictionaries, context) do
+    get(endpoint, %Query.Suggest{q: q, count: count, dictionary: dictionaries, cfq: context})
   end
 
   @doc """
@@ -252,7 +257,7 @@ defmodule Hui do
   ```
     # Index handler for JSON-formatted update
     headers = [{"content-type", "application/json"}]
-    url = {"http://localhost:8983/solr/collection/update", headers}
+    endpoint = {"http://localhost:8983/solr/collection/update", headers}
 
     # Solr docs in maps
     doc1 = %{
@@ -275,29 +280,29 @@ defmodule Hui do
       "name" => "Persona"
     }
 
-    Hui.update(url, doc1) # add a single doc
-    Hui.update(url, [doc1, doc2]) # add a list of docs
+    Hui.update(endpoint, doc1) # add a single doc
+    Hui.update(endpoint, [doc1, doc2]) # add a list of docs
 
     # Don't commit the docs e.g. mass ingestion when index handler is setup for autocommit. 
-    Hui.update(url, [doc1, doc2], false)
+    Hui.update(endpoint, [doc1, doc2], false)
 
     # Send to a configured endpoint
     Hui.update(:updater, [doc1, doc2])
 
     # Binary mode, add and commit a doc
-    Hui.update(url, "{\\\"add\\\":{\\\"doc\\\":{\\\"name\\\":\\\"Blade Runner\\\",\\\"id\\\":\\\"tt0083658\\\",..}},\\\"commit\\\":{}}")
+    Hui.update(endpoint, "{\\\"add\\\":{\\\"doc\\\":{\\\"name\\\":\\\"Blade Runner\\\",\\\"id\\\":\\\"tt0083658\\\",..}},\\\"commit\\\":{}}")
 
     # Binary mode, delete a doc via XML
     headers = [{"content-type", "application/xml"}]
-    url = {"http://localhost:8983/solr/collection/update", headers}
-    Hui.update(url, "<delete><id>9780141981727</id></delete>")
+    endpoint = {"http://localhost:8983/solr/collection/update", headers}
+    Hui.update(endpoint, "<delete><id>9780141981727</id></delete>")
 
   ```
 
   ### Example - `t:Hui.Query.Update.t/0` and other update options
   ```
 
-    # url, doc1, doc2 from the above example
+    # endpoint, doc1, doc2 from the above example
     ...
 
     # Hui.Query.Update struct command for updating and committing the docs to Solr within 5 seconds
@@ -305,25 +310,25 @@ defmodule Hui do
     alias Hui.Query
 
     x = %Query.Update{doc: [doc1, doc2], commitWithin: 5000, overwrite: true}
-    {status, resp} = Hui.update(url, x)
+    {status, resp} = Hui.update(endpoint, x)
 
     # Delete the docs by IDs, with a URL key from configuration
     {status, resp} = Hui.update(:library_update, %Query.Update{delete_id: ["tt1316540", "tt1650453"]})
 
     # Commit and optimise index, keep max index segments at 10
-    {status, resp} = Hui.update(url, %Query.Update{commit: true, waitSearcher: true, optimize: true, maxSegments: 10})
+    {status, resp} = Hui.update(endpoint, %Query.Update{commit: true, waitSearcher: true, optimize: true, maxSegments: 10})
 
     # Commit index, expunge deleted docs
-    {status, resp} = Hui.update(url, %Query.Update{commit: true, expungeDeletes: true})
+    {status, resp} = Hui.update(endpoint, %Query.Update{commit: true, expungeDeletes: true})
   ```
   """
-  @spec update(url, update_query, boolean) :: http_response
-  def update(url, docs, commit \\ true)
-  def update(url, docs, _commit) when is_binary(docs), do: post(url, docs)
-  def update(url, %Query.Update{} = docs, _commit), do: post(url, docs)
+  @spec update(endpoint, update_query, boolean) :: http_response
+  def update(endpoint, docs, commit \\ true)
+  def update(endpoint, docs, _commit) when is_binary(docs), do: post(endpoint, docs)
+  def update(endpoint, %Query.Update{} = docs, _commit), do: post(endpoint, docs)
 
-  def update(url, docs, commit) when is_map(docs) or is_list(docs) do
-    post(url, %Query.Update{doc: docs, commit: commit})
+  def update(endpoint, docs, commit) when is_map(docs) or is_list(docs) do
+    post(endpoint, %Query.Update{doc: docs, commit: commit})
   end
 
   @doc """
@@ -342,17 +347,17 @@ defmodule Hui do
   ```
     # Index handler for JSON-formatted update
     headers = [{"content-type", "application/json"}]
-    url = {"http://localhost:8983/solr/collection/update", headers}
+    endpoint = {"http://localhost:8983/solr/collection/update", headers}
 
-    Hui.delete(url, "tt2358891") # delete a single doc
-    Hui.delete(url, ["tt2358891", "tt1602620"]) # delete a list of docs
+    Hui.delete(endpoint, "tt2358891") # delete a single doc
+    Hui.delete(endpoint, ["tt2358891", "tt1602620"]) # delete a list of docs
 
-    Hui.delete(url, ["tt2358891", "tt1602620"], false) # delete without immediate commit
+    Hui.delete(endpoint, ["tt2358891", "tt1602620"], false) # delete without immediate commit
   ```
   """
-  @spec delete(url, binary | list(binary), boolean) :: http_response
-  def delete(url, ids, commit \\ true) when is_binary(ids) or is_list(ids) do
-    post(url, %Query.Update{delete_id: ids, commit: commit})
+  @spec delete(endpoint, binary | list(binary), boolean) :: http_response
+  def delete(endpoint, ids, commit \\ true) when is_binary(ids) or is_list(ids) do
+    post(endpoint, %Query.Update{delete_id: ids, commit: commit})
   end
 
   @doc """
@@ -371,15 +376,15 @@ defmodule Hui do
   ```
     # Index handler for JSON-formatted update
     headers = [{"content-type", "application/json"}]
-    url = {"http://localhost:8983/solr/collection", headers}
+    endpoint = {"http://localhost:8983/solr/collection", headers}
 
-    Hui.delete_by_query(url, "name:Persona") # delete with a single filter
-    Hui.delete_by_query(url, ["genre:Drama", "name:Persona"]) # delete with a list of filters
+    Hui.delete_by_query(endpoint, "name:Persona") # delete with a single filter
+    Hui.delete_by_query(endpoint, ["genre:Drama", "name:Persona"]) # delete with a list of filters
   ```
   """
-  @spec delete_by_query(url, binary | list(binary), boolean) :: http_response
-  def delete_by_query(url, q, commit \\ true) when is_binary(q) or is_list(q) do
-    post(url, %Query.Update{delete_query: q, commit: commit})
+  @spec delete_by_query(endpoint, binary | list(binary), boolean) :: http_response
+  def delete_by_query(endpoint, q, commit \\ true) when is_binary(q) or is_list(q) do
+    post(endpoint, %Query.Update{delete_query: q, commit: commit})
   end
 
   @doc """
@@ -400,18 +405,18 @@ defmodule Hui do
   ```
     # Index handler for JSON-formatted update
     headers = [{"content-type", "application/json"}]
-    url = {"http://localhost:8983/solr/collection", headers}
+    endpoint = {"http://localhost:8983/solr/collection", headers}
 
-    Hui.commit(url) # commits, make new docs available for search
-    Hui.commit(url, false) # commits op only, new docs to be made available later
+    Hui.commit(endpoint) # commits, make new docs available for search
+    Hui.commit(endpoint, false) # commits op only, new docs to be made available later
   ```
 
   Use `t:Hui.Query.Update.t/0` struct for other types of commit and index optimisation, e.g. expunge deleted docs to
   physically remove docs from the index, which could be a system-intensive operation.
   """
-  @spec commit(url, boolean) :: http_response
-  def commit(url, wait_searcher \\ true) do
-    post(url, %Query.Update{commit: true, waitSearcher: wait_searcher})
+  @spec commit(endpoint, boolean) :: http_response
+  def commit(endpoint, wait_searcher \\ true) do
+    post(endpoint, %Query.Update{commit: true, waitSearcher: wait_searcher})
   end
 
   @doc """
@@ -419,12 +424,12 @@ defmodule Hui do
 
   ### Example
   ```
-    url = {"http://localhost:8983/solr/admin/metrics", [{"content-type", "application/json"}]}
-    Hui.metrics(url, group: "core", type: "timer", property: ["mean_ms", "max_ms", "p99_ms"])
+    endpoint = {"http://localhost:8983/solr/admin/metrics", [{"content-type", "application/json"}]}
+    Hui.metrics(endpoint, group: "core", type: "timer", property: ["mean_ms", "max_ms", "p99_ms"])
   ```
   """
-  @spec commit(url, keyword) :: http_response
-  defdelegate metrics(url, options), to: Hui.Metrics
+  @spec commit(endpoint, keyword) :: http_response
+  defdelegate metrics(endpoint, options), to: Hui.Metrics
 
   @doc """
   Issues a get request of Solr query to a specific endpoint.
@@ -434,15 +439,15 @@ defmodule Hui do
   ## Example - parameters
 
   ```
-    url = "http://..."
+    endpoint = "http://..."
 
     # query via a list of keywords, which are unbound and sent to Solr directly
-    Hui.get(url, q: "glen cova", facet: "true", "facet.field": ["type", "year"])
+    Hui.get(endpoint, q: "glen cova", facet: "true", "facet.field": ["type", "year"])
 
     # query via Hui structs
     alias Hui.Query
-    Hui.get(url, %Query.DisMax{q: "glen cova"})
-    Hui.get(url, [%Query.DisMax{q: "glen"}, %Query.Facet{field: ["type", "year"]}])
+    Hui.get(endpoint, %Query.DisMax{q: "glen cova"})
+    Hui.get(endpoint, [%Query.DisMax{q: "glen"}, %Query.Facet{field: ["type", "year"]}])
   ```
 
   The use of structs is more idiomatic and succinct. It is bound to qualified Solr fields.
@@ -461,9 +466,9 @@ defmodule Hui do
   If `HTTPoison` is used, advanced HTTP options such as the use of connection pools
   may also be specified via `options`.
   """
-  @spec get(url, query) :: http_response
-  def get(url, query) do
-    with {:ok, {url, headers, options}} <- Utils.parse_endpoint(url) do
+  @spec get(endpoint, query) :: http_response
+  def get(endpoint, query) do
+    with {:ok, {url, headers, options}} <- Utils.parse_endpoint(endpoint) do
       %Http{
         url: [url, "?", Encoder.encode(query)],
         headers: headers,
@@ -478,9 +483,9 @@ defmodule Hui do
   @doc """
   Issues a POST request to a specific Solr endpoint, e.g. for data indexing and deletion.
   """
-  @spec post(url, update_query) :: http_response
-  def post(url, docs) do
-    with {:ok, {url, headers, options}} <- Utils.parse_endpoint(url) do
+  @spec post(endpoint, update_query) :: http_response
+  def post(endpoint, docs) do
+    with {:ok, {url, headers, options}} <- Utils.parse_endpoint(endpoint) do
       %Http{
         url: url,
         headers: headers,

--- a/lib/hui/utils.ex
+++ b/lib/hui/utils.ex
@@ -1,0 +1,52 @@
+defmodule Hui.Utils do
+  @moduledoc false
+
+  import Hui.Guards
+  alias Hui.Error
+
+  @configured_url Application.get_all_env(:hui)
+                  |> Enum.filter(fn {_k, v} -> is_list(v) and :url in Keyword.keys(v) end)
+                  |> Enum.into(%{}, fn {k, v} -> {k, Enum.into(v, %{})} end)
+
+  @type url :: Hui.url()
+  @type http_headers :: list
+  @type http_options :: list
+
+  @doc """
+  Parses Solr endpoint in various formats into {url, headers, options} tuple
+  for HTTP requests
+  """
+  @spec parse_endpoint(url) :: {:ok, {binary, http_headers, http_options}} | {:error, Error.t()}
+  def parse_endpoint("http://" <> _rest = url), do: {:ok, {url, [], []}}
+  def parse_endpoint("https://" <> _rest = url), do: {:ok, {url, [], []}}
+
+  def parse_endpoint({url, headers}), do: parse_endpoint({url, headers, []})
+  def parse_endpoint({url, headers, options}) when is_url(url, headers, options), do: {:ok, {url, headers, options}}
+
+  def parse_endpoint(config_key) when is_atom(config_key) do
+    case @configured_url[config_key][:url] do
+      url when is_url(url) ->
+        {
+          :ok,
+          {
+            build_url(@configured_url[config_key]),
+            Map.get(@configured_url[config_key], :headers, []),
+            Map.get(@configured_url[config_key], :options, [])
+          }
+        }
+
+      _ ->
+        {:error, %Error{reason: :nxdomain}}
+    end
+  end
+
+  def parse_endpoint(_url), do: {:error, %Error{reason: :nxdomain}}
+
+  defp build_url(%{url: url, collection: collection, handler: handler}), do: [url, "/", collection, "/", handler]
+  defp build_url(%{url: url, collection: collection}), do: [url, "/", collection]
+  defp build_url(%{url: url, handler: handler}), do: [url, "/", handler]
+  defp build_url(%{url: url}), do: url
+
+  @spec config_url(atom) :: binary
+  def config_url(key) when is_atom(key), do: @configured_url[key][:url]
+end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,0 +1,43 @@
+defmodule Hui.UtilsTest do
+  use ExUnit.Case, async: true
+  alias Hui.Utils
+
+  # see `:hui, :default` test configuration
+  test "parse_url/1 handles config endpoint with only url field" do
+    url = "http://localhost:8983/solr/gettingstarted/select"
+
+    assert {:ok, {^url, _headers, _options}} = Utils.parse_endpoint(:default)
+    assert url == Utils.config_url(:default)
+  end
+
+  # see `:hui, :url_handler` test configuration
+  test "parse_url/1 handles config endpoint with url, handler fields" do
+    url = "http://localhost:8983/solr/gettingstarted"
+    handler = "select"
+    parsed_url = [url, "/", handler]
+
+    assert {:ok, {^parsed_url, _headers, _options}} = Utils.parse_endpoint(:url_handler)
+    assert url == Utils.config_url(:url_handler)
+  end
+
+  # see `:hui, :url_collection` test configuration
+  test "parse_url/1 handles config endpoint with url, collection fields" do
+    url = "http://localhost:8983/solr"
+    collection = "gettingstarted"
+    parsed_url = [url, "/", collection]
+
+    assert {:ok, {^parsed_url, _headers, _options}} = Utils.parse_endpoint(:url_collection)
+    assert url == Utils.config_url(:url_collection)
+  end
+
+  # see `:hui, :url_collection_handler` test configuration
+  test "parse_url/1 handles config endpoint with url, collection, handler fields" do
+    url = "http://localhost:8983/solr"
+    collection = "gettingstarted"
+    handler = "update"
+    parsed_url = [url, "/", collection, "/", handler]
+
+    assert {:ok, {^parsed_url, _headers, _options}} = Utils.parse_endpoint(:url_collection_handler)
+    assert url == Utils.config_url(:url_collection_handler)
+  end
+end


### PR DESCRIPTION
This PR adds `collection`, `handler` fields in configuration and move endpoint parsing concerns into `Utils` module.